### PR TITLE
Add Jenkins groovy build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
     - name: Build with Maven
       env:
         MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
-      with:
-        run: mvn -f org.eclipse.swt.imagej.cbi/pom.xml verify
+      run: mvn -f org.eclipse.swt.imagej.cbi/pom.xml verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build with Maven
+      env:
+        MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
       with:
-        run: mvn -f org.eclipse.swt.imagej.cbi/pom.xml verify --batch-mode --no-transfer-progress
+        run: mvn -f org.eclipse.swt.imagej.cbi/pom.xml verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 Lablicate GmbH
+# Copyright (c) 2024, 2025 Lablicate GmbH
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: maven:3.9.4-eclipse-temurin-17
+      image: maven:3.9-eclipse-temurin-17
 
     steps:
     - name: Checkout SWT ImageJ

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+	agent {
+		kubernetes {
+			label 'ubuntu-latest'
+		}
+	}
+	triggers {
+		pollSCM('H/5 * * * *')
+	}
+	options {
+		disableConcurrentBuilds()
+	}
+	tools {
+		maven 'apache-maven-latest'
+		jdk   'temurin-jdk17-latest'
+	}
+	stages {
+		stage('Build') {
+			steps {
+				sh "mvn -f org.eclipse.swt.imagej.cbi/pom.xml -Peclipse-sign clean install"
+			}
+		}
+	}
+}


### PR DESCRIPTION
The matching Jenkins build creates code signed artifacts, but does not deploy yet. For GitHub Actions it now uses the [Maven environment variable](https://maven.apache.org/configure.html) and [colored output is supported by GitHub Actions](https://github.blog/news-insights/product-news/a-better-logs-experience-with-github-actions/#opening-the-door-to-a-more-colorful-experience) which helps with readability.