### PR TITLE
Use the GitHub web hook to trigger builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 		}
 	}
 	triggers {
-		pollSCM('H/5 * * * *')
+		githubPush()
 	}
 	options {
 		disableConcurrentBuilds()


### PR DESCRIPTION
https://plugins.jenkins.io/github/#plugin-content-github-hook-trigger-for-gitscm-polling is now possible thanks to https://github.com/eclipse-swtimagej/.eclipsefdn/pull/3/ which is more efficient than continuous polling.