### PR TITLE
Trim update site

### DIFF
--- a/org.eclipse.swt.imagej.updatesite/category.xml
+++ b/org.eclipse.swt.imagej.updatesite/category.xml
@@ -4,4 +4,5 @@
     <category name="org.eclipse.swt.imagej"/>
   </feature>
   <category-def name="org.eclipse.swt.imagej" label="Eclipse SWTImageJ" />
+  <repository-reference location="https://download.eclipse.org/releases/2025-06/" enabled="true" />
 </site>

--- a/org.eclipse.swt.imagej.updatesite/category.xml
+++ b/org.eclipse.swt.imagej.updatesite/category.xml
@@ -3,9 +3,5 @@
   <feature id="org.eclipse.swt.imagej.feature" version="1.5.0.qualifier">
     <category name="org.eclipse.swt.imagej"/>
   </feature>
-  <feature id="org.eclipse.swt.imagej.feature.source" version="1.5.0.qualifier">
-    <category name="org.eclipse.swt.imagej.source"/>
-  </feature>
   <category-def name="org.eclipse.swt.imagej" label="Eclipse SWTImageJ" />
-  <category-def name="org.eclipse.swt.imagej.source" label="Eclipse SWTImageJ Developer Resources"/>
 </site>

--- a/org.eclipse.swt.imagej.updatesite/pom.xml
+++ b/org.eclipse.swt.imagej.updatesite/pom.xml
@@ -23,6 +23,8 @@
         <version>${tycho.version}</version>
         <configuration>
           <includeAllDependencies>true</includeAllDependencies>
+          <filterProvided>true</filterProvided>
+          <includeAllSources>true</includeAllSources>
           <skipArchive>true</skipArchive>
         </configuration>
       </plugin>


### PR DESCRIPTION
This reduces https://download.eclipse.org/swtimagej/integration/ repository size from 50.9 MB → 5.5 MB.