### PR TITLE
Stop building source feature

### DIFF
--- a/org.eclipse.swt.imagej.feature/pom.xml
+++ b/org.eclipse.swt.imagej.feature/pom.xml
@@ -12,37 +12,4 @@
 	<artifactId>org.eclipse.swt.imagej.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<version>1.5.0-SNAPSHOT</version>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho.version}</version>
-
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>


### PR DESCRIPTION
It is not published. PDE/Tycho work just fine without it. Tycho 5 will deprecate it and Tycho 6 will remove support for it so it's best to keep the build clean.