### PR TITLE
Remove the need to manually specify SWT fragments

### DIFF
--- a/org.eclipse.swt.imagej/app/pom.xml
+++ b/org.eclipse.swt.imagej/app/pom.xml
@@ -22,14 +22,7 @@
 	</licenses>
 	
 	<packaging>jar</packaging>
-	<!--<properties>
-		<osgi.platform>cocoa.macosx.aarch64</osgi.platform>
-		<maven.compiler.release>21</maven.compiler.release>
-	</properties>-->
-	<!--<properties> <osgi.platform>gtk.linux.x86_64</osgi.platform> <maven.compiler.release>21</maven.compiler.release> 
-		</properties> -->
 	<properties> 
-	<osgi.platform>win32.win32.x86_64</osgi.platform> 
 			<maven.compiler.release>21</maven.compiler.release> 
 		</properties> 
 	<dependencies>
@@ -43,105 +36,50 @@
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.core.commands</artifactId>
-			<version>3.12.300</version>
+			<version>3.12.400</version>
 
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.core.runtime</artifactId>
-			<version>3.33.0</version>
+			<version>3.34.0</version>
 
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.equinox.common</artifactId>
-			<version>3.20.0</version>
+			<version>3.20.200</version>
 
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.jface</artifactId>
-			<version>3.36.0</version>
+			<version>3.38.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.jface.text</artifactId>
-			<version>3.27.0</version>
+			<version>3.28.100</version>
 
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.text</artifactId>
-			<version>3.14.300</version>
+			<version>3.14.400</version>
 
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.osgi</artifactId>
-			<version>3.22.0</version>
+			<version>3.23.200</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.swt</artifactId>
-			<version>3.129.0</version>
+			<version>3.131.0</version>
 
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<id>windows</id>
-			<activation>
-				<os>
-					<family>Windows</family>
-				</os>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.platform</groupId>
-					<artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-					<version>3.129.0</version>
-					
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>linux</id>
-			<activation>
-				<os>
-					<name>Linux</name>
-				</os>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.platform</groupId>
-					<artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-					<version>3.129.0</version>
-					
-				</dependency>
-			</dependencies>
-		</profile>
-		<!--<profile> <id>mac-x86_64</id> <activation> <os> <family>mac</family> 
-			<arch>x86_64</arch> </os> </activation> <dependencies> <dependency> <groupId>org.eclipse.platform</groupId> 
-			<artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId> <version>3.129.0</version> 
-			<scope>system</scope> </dependency> </dependencies> </profile> -->
-		<profile>
-			<id>mac-aarch64</id>
-			<activation>
-				<os>
-					<family>mac</family>
-					<arch>aarch64</arch>
-				</os>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.platform</groupId>
-					<artifactId>org.eclipse.swt.cocoa.macosx.aarch64</artifactId>
-					<version>3.129.0</version>
-				</dependency>
-			</dependencies>
-		</profile>
-	</profiles>
-
 	<build>
 		<!-- Package all required ImageJ folders and files in the exported *.jar! -->
 		<sourceDirectory>${project.basedir}</sourceDirectory>


### PR DESCRIPTION
It even reduces the possible problem of getting *.130 host with *.129 fragment which can fail in unpredictable way.