### PR TITLE
Run maven-enforcer-plugin only once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.6.2</version>
+        <inherited>false</inherited>
         <executions>
           <execution>
             <id>enforce-maven</id>


### PR DESCRIPTION
Running it once per build is enough, there is no need to verify maven version for each module separately - it can't change.