### PR TITLE
Run license vetting only on target file change

### DIFF
--- a/.github/workflows/licensevetting.yml
+++ b/.github/workflows/licensevetting.yml
@@ -6,9 +6,13 @@ on:
   push:
     branches: 
       - 'develop'
+    paths:
+      - '**/*.target'
   pull_request:
     branches: 
      - 'develop'
+    paths:
+     - '**/*.target'
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
See https://github.com/eclipse-dash/dash-licenses/issues/448 for the upstream issue.