### PR TITLE
Build against 2026-06

### DIFF
--- a/org.eclipse.swt.imagej.targetplatform/org.eclipse.swtchart.targetplatform.target
+++ b/org.eclipse.swt.imagej.targetplatform/org.eclipse.swtchart.targetplatform.target
@@ -3,8 +3,7 @@
 <target name="Eclipse SWT ImageJ" sequenceNumber="3">
 <locations>
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/releases/2026-03/"/>
-		<unit id="org.eclipse.swt"/>
+		<repository location="https://download.eclipse.org/releases/2026-06/"/>
 		<unit id="org.eclipse.ui"/>
 		<unit id="org.eclipse.jface.text"/>
 	</location>

--- a/org.eclipse.swt.imagej.updatesite/category.xml
+++ b/org.eclipse.swt.imagej.updatesite/category.xml
@@ -4,5 +4,5 @@
       <category name="org.eclipse.swt.imagej"/>
    </feature>
    <category-def name="org.eclipse.swt.imagej" label="Eclipse SWTImageJ"/>
-   <repository-reference location="https://download.eclipse.org/releases/2026-03/" name="" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/releases/2026-06/" name="" enabled="true" />
 </site>


### PR DESCRIPTION
As planner mode is used there is no need to explicitly require swt as it's dependency of the others.